### PR TITLE
add'f' option in copyfile command

### DIFF
--- a/fitting/ODMR_to_B111.m
+++ b/fitting/ODMR_to_B111.m
@@ -106,8 +106,8 @@ for i = 1:size(nFolders,2)
             msg = sprintf('copying laser.jpg, laser.csv into %s', dataFolder);
             logMsg('info',msg,1,0);
 
-            copyfile(fullfile(dataFolder, 'laser.csv'),fullfile(dataFolder, folderName))
-            copyfile(fullfile(dataFolder, 'laser.jpg'),fullfile(dataFolder, folderName))
+            copyfile(fullfile(dataFolder, 'laser.csv'),fullfile(dataFolder, folderName), 'f')
+            copyfile(fullfile(dataFolder, 'laser.jpg'),fullfile(dataFolder, folderName), 'f')
 
             fName = sprintf('final_fits_(%ix%i).mat', binSize, binSize);
             msg = sprintf('saving %s into %s', fName, dataFolder);


### PR DESCRIPTION
adding this parameter helps saving laser image files in proccessed B111 data folder. Otherwise an error of "Cannot write to destination: xxxxxxx.  Use the 'f' option to override." will show up